### PR TITLE
Change Transaction code flow to be asynchronous

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,0 @@
-export CLIENT_ID=<client_id>
-export PUBLIC_KEY=<public_key>
-export SECRET=<secret>
-
-"$@"

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ docs/.doctrees
 docs/objects.inv
 
 dist
+
+.idea/*

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,20 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+cov-core = "*"
+coverage = "*"
+flake8 = "*"
+mock = "*"
+py = "*"
+aiohttp = "*"
+pytest = "*"
+pytest-asyncio = "*"
+
+[requires]
+python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,287 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "cb4c6377fa70f3e85534b5ed70a86ed5b66d473071dc9f1b7c9e7129bac49d54"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "aiohttp": {
+            "hashes": [
+                "sha256:1e984191d1ec186881ffaed4581092ba04f7c61582a177b187d3a2f07ed9719e",
+                "sha256:259ab809ff0727d0e834ac5e8a283dc5e3e0ecc30c4d80b3cd17a4139ce1f326",
+                "sha256:2f4d1a4fdce595c947162333353d4a44952a724fba9ca3205a3df99a33d1307a",
+                "sha256:32e5f3b7e511aa850829fbe5aa32eb455e5534eaa4b1ce93231d00e2f76e5654",
+                "sha256:344c780466b73095a72c616fac5ea9c4665add7fc129f285fbdbca3cccf4612a",
+                "sha256:460bd4237d2dbecc3b5ed57e122992f60188afe46e7319116da5eb8a9dfedba4",
+                "sha256:4c6efd824d44ae697814a2a85604d8e992b875462c6655da161ff18fd4f29f17",
+                "sha256:50aaad128e6ac62e7bf7bd1f0c0a24bc968a0c0590a726d5a955af193544bcec",
+                "sha256:6206a135d072f88da3e71cc501c59d5abffa9d0bb43269a6dcd28d66bfafdbdd",
+                "sha256:65f31b622af739a802ca6fd1a3076fd0ae523f8485c52924a89561ba10c49b48",
+                "sha256:ae55bac364c405caa23a4f2d6cfecc6a0daada500274ffca4a9230e7129eac59",
+                "sha256:b778ce0c909a2653741cb4b1ac7015b5c130ab9c897611df43ae6a58523cb965"
+            ],
+            "index": "pypi",
+            "version": "==3.6.2"
+        },
+        "async-timeout": {
+            "hashes": [
+                "sha256:0c3c816a028d47f659d6ff5c745cb2acf1f966da1fe5c19c77a70282b25f4c5f",
+                "sha256:4291ca197d287d274d0b6cb5d6f8f8f82d434ed288f962539ff18cc9012f9ea3"
+            ],
+            "version": "==3.0.1"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c",
+                "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"
+            ],
+            "version": "==19.3.0"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:017c25db2a153ce562900032d5bc68e9f191e44e9a0f762f373977de9df1fbb3",
+                "sha256:25b64c7da4cd7479594d035c08c2d809eb4aab3a26e5a990ea98cc450c320f1f"
+            ],
+            "version": "==2019.11.28"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "cov-core": {
+            "hashes": [
+                "sha256:4a14c67d520fda9d42b0da6134638578caae1d374b9bb462d8de00587dba764c"
+            ],
+            "index": "pypi",
+            "version": "==1.15.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:0cd13a6e98c37b510a2d34c8281d5e1a226aaf9b65b7d770ef03c63169965351",
+                "sha256:1a4b6b6a2a3a6612e6361130c2cc3dc4378d8c221752b96167ccbad94b47f3cd",
+                "sha256:2ee55e6dba516ddf6f484aa83ccabbb0adf45a18892204c23486938d12258cde",
+                "sha256:3be5338a2eb4ef03c57f20917e1d12a1fd10e3853fed060b6d6b677cb3745898",
+                "sha256:44b783b02db03c4777d8cf71bae19eadc171a6f2a96777d916b2c30a1eb3d070",
+                "sha256:475bf7c4252af0a56e1abba9606f1e54127cdf122063095c75ab04f6f99cf45e",
+                "sha256:47c81ee687eafc2f1db7f03fbe99aab81330565ebc62fb3b61edfc2216a550c8",
+                "sha256:4a7f8e72b18f2aca288ff02255ce32cc830bc04d993efbc87abf6beddc9e56c0",
+                "sha256:50197163a22fd17f79086e087a787883b3ec9280a509807daf158dfc2a7ded02",
+                "sha256:56b13000acf891f700f5067512b804d1ec8c301d627486c678b903859d07f798",
+                "sha256:79388ae29c896299b3567965dbcd93255f175c17c6c7bca38614d12718c47466",
+                "sha256:79fd5d3d62238c4f583b75d48d53cdae759fe04d4fb18fe8b371d88ad2b6f8be",
+                "sha256:7fe3e2fde2bf1d7ce25ebcd2d3de3650b8d60d9a73ce6dcef36e20191291613d",
+                "sha256:81042a24f67b96e4287774014fa27220d8a4d91af1043389e4d73892efc89ac6",
+                "sha256:81326f1095c53111f8afc95da281e1414185f4a538609a77ca50bdfa39a6c207",
+                "sha256:8873dc0d8f42142ea9f20c27bbdc485190fff93823c6795be661703369e5877d",
+                "sha256:88d2cbcb0a112f47eef71eb95460b6995da18e6f8ca50c264585abc2c473154b",
+                "sha256:91f2491aeab9599956c45a77c5666d323efdec790bfe23fcceafcd91105d585a",
+                "sha256:979daa8655ae5a51e8e7a24e7d34e250ae8309fd9719490df92cbb2fe2b0422b",
+                "sha256:9c871b006c878a890c6e44a5b2f3c6291335324b298c904dc0402ee92ee1f0be",
+                "sha256:a6d092545e5af53e960465f652e00efbf5357adad177b2630d63978d85e46a72",
+                "sha256:b5ed7837b923d1d71c4f587ae1539ccd96bfd6be9788f507dbe94dab5febbb5d",
+                "sha256:ba259f68250f16d2444cbbfaddaa0bb20e1560a4fdaad50bece25c199e6af864",
+                "sha256:be1d89614c6b6c36d7578496dc8625123bda2ff44f224cf8b1c45b810ee7383f",
+                "sha256:c1b030a79749aa8d1f1486885040114ee56933b15ccfc90049ba266e4aa2139f",
+                "sha256:c95bb147fab76f2ecde332d972d8f4138b8f2daee6c466af4ff3b4f29bd4c19e",
+                "sha256:d52c1c2d7e856cecc05aa0526453cb14574f821b7f413cc279b9514750d795c1",
+                "sha256:d609a6d564ad3d327e9509846c2c47f170456344521462b469e5cb39e48ba31c",
+                "sha256:e1bad043c12fb58e8c7d92b3d7f2f49977dcb80a08a6d1e7a5114a11bf819fca",
+                "sha256:e5a675f6829c53c87d79117a8eb656cc4a5f8918185a32fc93ba09778e90f6db",
+                "sha256:fec32646b98baf4a22fdceb08703965bd16dea09051fbeb31a04b5b6e72b846c"
+            ],
+            "index": "pypi",
+            "version": "==5.0"
+        },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:45681a117ecc81e870cbf1262835ae4af5e7a8b08e40b944a8a6e6b895914cfb",
+                "sha256:49356e766643ad15072a789a20915d3c91dc89fd313ccd71802303fd67e4deca"
+            ],
+            "index": "pypi",
+            "version": "==3.7.9"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:83657d894c90d5681d62155c82bda9c1187827525880eda8ff5df4ec813437c3",
+                "sha256:d157e52d4e5b938c550f39eb2fd15610db062441a9c2747d3dbfa9298211d0f8"
+            ],
+            "index": "pypi",
+            "version": "==3.0.5"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:b84b238cce0d9adad5ed87e745778d20a3f8487d0f0cb8b8a586816c7496458d",
+                "sha256:c833ef592a0324bcc6a60e48440da07645063c453880c9477ceb22490aec1564"
+            ],
+            "version": "==8.0.2"
+        },
+        "multidict": {
+            "hashes": [
+                "sha256:09c19f642e055550c9319d5123221b7e07fc79bda58122aa93910e52f2ab2f29",
+                "sha256:0c1a5d5f7aa7189f7b83c4411c2af8f1d38d69c4360d5de3eea129c65d8d7ce2",
+                "sha256:12f22980e7ed0972a969520fb1e55682c9fca89a68b21b49ec43132e680be812",
+                "sha256:258660e9d6b52de1a75097944e12718d3aa59adc611b703361e3577d69167aaf",
+                "sha256:3374a23e707848f27b3438500db0c69eca82929337656fce556bd70031fbda74",
+                "sha256:503b7fce0054c73aa631cc910a470052df33d599f3401f3b77e54d31182525d5",
+                "sha256:6ce55f2c45ffc90239aab625bb1b4864eef33f73ea88487ef968291fbf09fb3f",
+                "sha256:725496dde5730f4ad0a627e1a58e2620c1bde0ad1c8080aae15d583eb23344ce",
+                "sha256:a3721078beff247d0cd4fb19d915c2c25f90907cf8d6cd49d0413a24915577c6",
+                "sha256:ba566518550f81daca649eded8b5c7dd09210a854637c82351410aa15c49324a",
+                "sha256:c42362750a51a15dc905cb891658f822ee5021bfbea898c03aa1ed833e2248a5",
+                "sha256:cf14aaf2ab067ca10bca0b14d5cbd751dd249e65d371734bc0e47ddd8fafc175",
+                "sha256:cf24e15986762f0e75a622eb19cfe39a042e952b8afba3e7408835b9af2be4fb",
+                "sha256:d7b6da08538302c5245cd3103f333655ba7f274915f1f5121c4f4b5fbdb3febe",
+                "sha256:e27e13b9ff0a914a6b8fb7e4947d4ac6be8e4f61ede17edffabd088817df9e26",
+                "sha256:e53b205f8afd76fc6c942ef39e8ee7c519c775d336291d32874082a87802c67c",
+                "sha256:ec804fc5f68695d91c24d716020278fcffd50890492690a7e1fef2e741f7172c"
+            ],
+            "version": "==4.7.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:28b924174df7a2fa32c1953825ff29c61e2f5e082343165438812f00d3a7fc47",
+                "sha256:d9551545c6d761f3def1677baf08ab2a3ca17c56879e70fecba2fc4dde4ed108"
+            ],
+            "version": "==19.2"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa",
+                "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
+            ],
+            "index": "pypi",
+            "version": "==1.8.0"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+            ],
+            "version": "==2.1.1"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:20f995ecd72f2a1f4bf6b072b63b22e2eb457836601e76d6e5dfcd75436acc1f",
+                "sha256:4ca62001be367f01bd3e92ecbb79070272a9d4964dce6a48a82ff0b8bc7e683a"
+            ],
+            "version": "==2.4.5"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:6b571215b5a790f9b41f19f3531c53a45cf6bb8ef2988bc1ff9afb38270b25fa",
+                "sha256:e41d489ff43948babd0fad7ad5e49b8735d5d55e26628a58673c39ff61d95de4"
+            ],
+            "index": "pypi",
+            "version": "==5.3.2"
+        },
+        "pytest-asyncio": {
+            "hashes": [
+                "sha256:9fac5100fd716cbecf6ef89233e8590a4ad61d729d1732e0a96b84182df1daaf",
+                "sha256:d734718e25cfc32d2bf78d346e99d33724deeba774cc4afdf491530c6184b63b"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
+                "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
+            ],
+            "index": "pypi",
+            "version": "==2.22.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1f1b7d42e254082a9db6279deae68afb421ceba6158efa6131de7b3003ee93fd",
+                "sha256:30f610279e8b2578cab6db20741130331735c781b56053c59c4076da27f06b66"
+            ],
+            "version": "==1.13.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:a8a318824cc77d1fd4b2bec2ded92646630d7fe8619497b142c84a9e6f5a7293",
+                "sha256:f3c5fd51747d450d4dcf6f923c81f78f811aab8205fda64b0aba34a4e48b0745"
+            ],
+            "version": "==1.25.7"
+        },
+        "wcwidth": {
+            "hashes": [
+                "sha256:3df37372226d6e63e1b1e1eda15c594bca98a22d33a23832a90998faa96bc65e",
+                "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
+            ],
+            "version": "==0.1.7"
+        },
+        "yarl": {
+            "hashes": [
+                "sha256:0c2ab325d33f1b824734b3ef51d4d54a54e0e7a23d13b86974507602334c2cce",
+                "sha256:0ca2f395591bbd85ddd50a82eb1fde9c1066fafe888c5c7cc1d810cf03fd3cc6",
+                "sha256:2098a4b4b9d75ee352807a95cdf5f10180db903bc5b7270715c6bbe2551f64ce",
+                "sha256:25e66e5e2007c7a39541ca13b559cd8ebc2ad8fe00ea94a2aad28a9b1e44e5ae",
+                "sha256:26d7c90cb04dee1665282a5d1a998defc1a9e012fdca0f33396f81508f49696d",
+                "sha256:308b98b0c8cd1dfef1a0311dc5e38ae8f9b58349226aa0533f15a16717ad702f",
+                "sha256:3ce3d4f7c6b69c4e4f0704b32eca8123b9c58ae91af740481aa57d7857b5e41b",
+                "sha256:58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b",
+                "sha256:5b10eb0e7f044cf0b035112446b26a3a2946bca9d7d7edb5e54a2ad2f6652abb",
+                "sha256:6faa19d3824c21bcbfdfce5171e193c8b4ddafdf0ac3f129ccf0cdfcb083e462",
+                "sha256:944494be42fa630134bf907714d40207e646fd5a94423c90d5b514f7b0713fea",
+                "sha256:a161de7e50224e8e3de6e184707476b5a989037dcb24292b391a3d66ff158e70",
+                "sha256:a4844ebb2be14768f7994f2017f70aca39d658a96c786211be5ddbe1c68794c1",
+                "sha256:c2b509ac3d4b988ae8769901c66345425e361d518aecbe4acbfc2567e416626a",
+                "sha256:c9959d49a77b0e07559e579f38b2f3711c2b8716b8410b320bf9713013215a1b",
+                "sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080",
+                "sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2"
+            ],
+            "version": "==1.4.2"
+        }
+    },
+    "develop": {}
+}

--- a/plaid/api/item.py
+++ b/plaid/api/item.py
@@ -4,14 +4,14 @@ from plaid.api.api import API
 class PublicToken(API):
     '''Endpoints for translating between public tokens and access tokens.'''
 
-    def exchange(self, public_token):
+    async def exchange(self, public_token):
         '''
         Exchange a Link public_token for an API access_token.
         (`HTTP docs <https://plaid.com/docs/api/#exchange-token-flow>`__)
 
         :param  str     public_token:
         '''
-        return self.client.post('/item/public_token/exchange', {
+        return await self.client.post('/item/public_token/exchange', {
             'public_token': public_token,
         })
 
@@ -102,7 +102,7 @@ class Item(API):
             'access_token': access_token,
         })
 
-    def remove(self, access_token):
+    async def remove(self, access_token):
         '''
         Remove an item.
         (`HTTP docs <https://plaid.com/docs/api/#remove-an-item>`__)
@@ -111,6 +111,6 @@ class Item(API):
 
         :param  str     access_token:
         '''
-        return self.client.post('/item/remove', {
+        return await self.client.post('/item/remove', {
             'access_token': access_token,
         })

--- a/plaid/api/transactions.py
+++ b/plaid/api/transactions.py
@@ -4,15 +4,15 @@ from plaid.api.api import API
 class Transactions(API):
     '''Transactions endpoints.'''
 
-    def get(self,
-            access_token,
-            start_date,
-            end_date,
-            _options=None,
-            account_ids=None,
-            count=None,
-            offset=None,
-            ):
+    async def get(self,
+                  access_token,
+                  start_date,
+                  end_date,
+                  _options=None,
+                  account_ids=None,
+                  count=None,
+                  offset=None,
+                  ):
         '''
         Return accounts and transactions for an item.
         (`HTTP docs <https://plaid.com/docs/api/#transactions>`__)
@@ -42,7 +42,7 @@ class Transactions(API):
         if offset is not None:
             options['offset'] = offset
 
-        return self.client.post('/transactions/get', {
+        return await self.client.post('/transactions/get', {
             'access_token': access_token,
             'start_date': start_date,
             'end_date': end_date,

--- a/plaid/client.py
+++ b/plaid/client.py
@@ -88,34 +88,34 @@ class Client(object):
         self.Sandbox = Sandbox(self)
         self.Transactions = Transactions(self)
 
-    def post(self, path, data, is_json=True):
+    async def post(self, path, data, is_json=True):
         '''Make a post request with client_id and secret key.'''
         post_data = {
             'client_id': self.client_id,
             'secret': self.secret,
         }
         post_data.update(data)
-        return self._post(path, post_data, is_json)
+        return await self._post(path, post_data, is_json)
 
-    def post_public(self, path, data, is_json=True):
+    async def post_public(self, path, data, is_json=True):
         '''Make a post request requiring no auth.'''
-        return self._post(path, data, is_json)
+        return await self._post(path, data, is_json)
 
-    def post_public_key(self, path, data, is_json=True):
+    async def post_public_key(self, path, data, is_json=True):
         '''Make a post request using a public key.'''
         post_data = {
             'public_key': self.public_key
         }
         post_data.update(data)
-        return self._post(path, post_data, is_json)
+        return await self._post(path, post_data, is_json)
 
-    def _post(self, path, data, is_json):
+    async def _post(self, path, data, is_json):
         headers = {}
         if self.api_version is not None:
             headers['Plaid-Version'] = self.api_version
         if self.client_app is not None:
             headers['Plaid-Client-App'] = self.client_app
-        return post_request(
+        return await post_request(
             urljoin('https://' + self.environment + '.plaid.com', path),
             data=data,
             timeout=self.timeout,

--- a/tests/integration/test_transactions.py
+++ b/tests/integration/test_transactions.py
@@ -1,5 +1,7 @@
 import time
 
+import pytest
+
 from plaid.errors import ItemError
 from tests.integration.util import (
     create_client,
@@ -9,36 +11,45 @@ from tests.integration.util import (
 access_token = None
 
 
-def setup_module(module):
+@pytest.fixture
+async def set_up_and_tear_down_client():
+    print('Setup started')
     client = create_client()
-    pt_response = client.Sandbox.public_token.create(
+    pt_response = await client.Sandbox.public_token.create(
         SANDBOX_INSTITUTION, ['transactions'],
         transactions__start_date='2016-01-01',
         transactions__end_date='2017-01-01',
     )
-    exchange_response = client.Item.public_token.exchange(
+    exchange_response = await client.Item.public_token.exchange(
         pt_response['public_token'])
     global access_token
     access_token = exchange_response['access_token']
+    print('Setup complete')
+
+    yield
+
+    print('Teardown started')
+    await client.Item.remove(access_token)
+    print('Teardown complete')
 
 
-def get_transactions_with_retries(client,
-                                  access_token,
-                                  start_date,
-                                  end_date,
-                                  account_ids=None,
-                                  count=None,
-                                  offset=None,
-                                  num_retries=5):
+async def get_transactions_with_retries(client,
+                                        _access_token,
+                                        start_date,
+                                        end_date,
+                                        account_ids=None,
+                                        count=None,
+                                        offset=None,
+                                        num_retries=5):
     response = None
     for i in range(num_retries):
         try:
-            response = client.Transactions.get(access_token,
-                                               start_date,
-                                               end_date,
-                                               account_ids=account_ids,
-                                               count=count,
-                                               offset=offset)
+            response = await client.Transactions.get(_access_token,
+                                                     start_date,
+                                                     end_date,
+                                                     account_ids=account_ids,
+                                                     count=count,
+                                                     offset=offset)
         except ItemError as ie:
             if ie.code == u'PRODUCT_NOT_READY':
                 time.sleep(5)
@@ -49,39 +60,36 @@ def get_transactions_with_retries(client,
     return response
 
 
-def teardown_module(module):
-    client = create_client()
-    client.Item.remove(access_token)
-
-
-def test_get():
+@pytest.mark.asyncio
+async def test_get(set_up_and_tear_down_client):
     client = create_client()
 
-    response = get_transactions_with_retries(client,
-                                             access_token,
-                                             '2016-01-01',
-                                             '2017-01-01',
-                                             num_retries=5)
+    response = await get_transactions_with_retries(client,
+                                                   access_token,
+                                                   '2016-01-01',
+                                                   '2017-01-01',
+                                                   num_retries=5)
     assert response['accounts'] is not None
     assert response['transactions'] is not None
 
     # get transactions for selected accounts
     account_id = response['accounts'][0]['account_id']
-    response = get_transactions_with_retries(client,
-                                             access_token,
-                                             '2016-01-01',
-                                             '2017-01-01',
-                                             account_ids=[account_id],
-                                             num_retries=5)
+    response = await get_transactions_with_retries(client,
+                                                   access_token,
+                                                   '2016-01-01',
+                                                   '2017-01-01',
+                                                   account_ids=[account_id],
+                                                   num_retries=5)
     assert response['transactions'] is not None
 
 
-def test_get_with_options():
+@pytest.mark.asyncio
+async def test_get_with_options(set_up_and_tear_down_client):
     client = create_client()
-    response = get_transactions_with_retries(client,
-                                             access_token,
-                                             '2016-01-01',
-                                             '2017-01-01',
-                                             count=2,
-                                             offset=1)
+    response = await get_transactions_with_retries(client,
+                                                   access_token,
+                                                   '2016-01-01',
+                                                   '2017-01-01',
+                                                   count=2,
+                                                   offset=1)
     assert len(response['transactions']) == 2


### PR DESCRIPTION
This was a proof of concept: Can we easily make this code asynchronous? Since we are most interested in syncing transactions, I started with this code path. I used pytest and the existing (but since modified to support async) test_transactions.py file to ensure that the code worked. This file previously had setup and teardown modules that seemed to get called by default on set up and tear down. I couldn't find an easy way to get these to be registered on the event loop / run before and after the test properly. Instead, I combined the functionality into a pytest fixture and yielded in the middle. This seemed to work great! 