### PR TITLE
Pass a aiohttp session

### DIFF
--- a/plaid/client.py
+++ b/plaid/client.py
@@ -36,10 +36,12 @@ class Client(object):
                  secret,
                  public_key,
                  environment,
+                 request_session,
                  suppress_warnings=False,
                  timeout=DEFAULT_TIMEOUT,
                  api_version=None,
-                 client_app=None):
+                 client_app=None,
+                 ):
         '''
         Initialize a client with credentials.
 
@@ -53,7 +55,7 @@ class Client(object):
         :arg    str     api_version:        API version to use for requests
         :arg    str     client_app:         Internal header to include
                                             in requests
-
+        :arg            request_session:    aiohttp ClientSession for http request
         '''
         self.client_id = client_id
         self.secret = secret
@@ -63,6 +65,7 @@ class Client(object):
         self.timeout = timeout
         self.api_version = api_version
         self.client_app = client_app
+        self.request_session = request_session
 
         if self.environment == 'development' and not self.suppress_warnings:
             warnings.warn('''
@@ -117,6 +120,7 @@ class Client(object):
             headers['Plaid-Client-App'] = self.client_app
         return await post_request(
             urljoin('https://' + self.environment + '.plaid.com', path),
+            request_session=self.request_session,
             data=data,
             timeout=self.timeout,
             is_json=is_json,

--- a/plaid/requester.py
+++ b/plaid/requester.py
@@ -25,7 +25,6 @@ async def _requests_http_request(
     normalized_method = method.lower()
     headers.update({'User-Agent': 'Plaid Python v{}'.format(__version__)})
     if normalized_method in ALLOWED_METHODS:
-        # async with aiohttp.ClientSession() as session:
         return await getattr(request_session, normalized_method)(
             url,
             json=data,

--- a/plaid/requester.py
+++ b/plaid/requester.py
@@ -1,4 +1,3 @@
-import aiohttp
 import json
 
 from functools import partial
@@ -18,6 +17,7 @@ except ImportError:
 
 async def _requests_http_request(
         url,
+        request_session,
         method,
         data,
         headers,
@@ -25,13 +25,13 @@ async def _requests_http_request(
     normalized_method = method.lower()
     headers.update({'User-Agent': 'Plaid Python v{}'.format(__version__)})
     if normalized_method in ALLOWED_METHODS:
-        async with aiohttp.ClientSession() as session:
-            return await getattr(session, normalized_method)(
-                url,
-                json=data,
-                headers=headers,
-                timeout=timeout,
-            )
+        # async with aiohttp.ClientSession() as session:
+        return await getattr(request_session, normalized_method)(
+            url,
+            json=data,
+            headers=headers,
+            timeout=timeout,
+        )
     else:
         raise Exception(
             'Invalid request method {}'.format(method)
@@ -40,6 +40,7 @@ async def _requests_http_request(
 
 async def http_request(
         url,
+        request_session,
         method=None,
         data=None,
         headers=None,
@@ -47,6 +48,7 @@ async def http_request(
         is_json=True):
     response = await _requests_http_request(
         url,
+        request_session,
         method,
         data or {},
         headers or {},


### PR DESCRIPTION
Allows user to pass in an existing http request connection for the purposes of making api calls. I just noticed that it would probably be useful to by default instantiate one aiohttp client session with the creation of a Client Object if one is not provided. I can make that update as well